### PR TITLE
Fix constant mpoly assignment in +.mpoly

### DIFF
--- a/R/mpolyArithmetic.R
+++ b/R/mpolyArithmetic.R
@@ -42,14 +42,14 @@ NULL
   ## if either is constant, mpoly it
   if(!is.list(e1)){
     stopifnot(is.numeric(e1) && length(e1) == 1)
-    e1 <- list(coef = e1)
+    e1 <- list(c(coef = e1))
   }
   
   if(!is.list(e2)){
     stopifnot(is.numeric(e2) && length(e2) == 1)
     e2 <- list(c(coef = e2))
   }
-	
+
   ## let mpoly do the heavy lifting
   mpoly(c(e1, e2)) 
 }


### PR DESCRIPTION
If someone writes, for example `0 + mp("x")`, the result is `1 + x` . I believe this commit fixes it, as there was an error in `+.mpoly` in making the constant a constant polynomial, as is obvious in the diff. The result was that the constant became an single unnamed element list, so in `mpoly`, the "coef" = 1 field was added, as no "coef" field could be found in the vector, thus giving `1 + x` instead of `x`.